### PR TITLE
removed transformers upper bound

### DIFF
--- a/stm-lifted.cabal
+++ b/stm-lifted.cabal
@@ -1,5 +1,5 @@
 name:		stm-lifted
-version:        0.1.0.0
+version:        0.1.1.0
 synopsis:	Software Transactional Memory lifted to MonadIO
 license:	BSD3
 license-file:	LICENSE
@@ -35,6 +35,6 @@ library
   other-modules: Internal
   build-depends:
       base          >= 4.5   && < 5
-    , transformers  >= 0.2   && < 0.4
+    , transformers  >= 0.2   
     , stm           >= 2.4.2 && < 3
 


### PR DESCRIPTION
Hi Max - this is just a quick fix to avoid cabal dependency conflict when building inyaface.
