### PR TITLE
Update for stm-2.4, transformers-0.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 *.[ao]
 *.hi
+.stack-work

--- a/src/Control/Concurrent/STM/TBQueue/Lifted.hs
+++ b/src/Control/Concurrent/STM/TBQueue/Lifted.hs
@@ -1,11 +1,11 @@
 module Control.Concurrent.STM.TBQueue.Lifted
     ( module All
-	, newTBQueueIO
-	, readTBQueueIO
-	, tryReadTBQueueIO
-	, peekTBQueueIO
-	, tryPeekTBQueueIO
-	, writeTBQueueIO
+    , newTBQueueIO
+    , readTBQueueIO
+    , tryReadTBQueueIO
+    , peekTBQueueIO
+    , tryPeekTBQueueIO
+    , writeTBQueueIO
     , unGetTBQueueIO
     , isEmptyTBQueueIO
     ) where

--- a/src/Control/Concurrent/STM/TBQueue/Lifted.hs
+++ b/src/Control/Concurrent/STM/TBQueue/Lifted.hs
@@ -8,6 +8,7 @@ module Control.Concurrent.STM.TBQueue.Lifted
     , writeTBQueueIO
     , unGetTBQueueIO
     , isEmptyTBQueueIO
+    , isFullTBQueueIO
     ) where
 
 import Control.Concurrent.STM.TBQueue as All hiding (newTBQueueIO)
@@ -40,3 +41,6 @@ unGetTBQueueIO = atomically .: unGetTBQueue
 
 isEmptyTBQueueIO :: MonadIO m => TBQueue a -> m Bool
 isEmptyTBQueueIO = atomically . isEmptyTBQueue
+
+isFullTBQueueIO :: MonadIO m => TBQueue a -> m Bool
+isFullTBQueueIO = atomically . isFullTBQueue

--- a/src/Control/Concurrent/STM/TChan/Lifted.hs
+++ b/src/Control/Concurrent/STM/TChan/Lifted.hs
@@ -1,18 +1,17 @@
 module Control.Concurrent.STM.TChan.Lifted
     ( module All
-	, newTChanIO
-	, newBroadcastTChanIO
+    , newTChanIO
+    , newBroadcastTChanIO
     , dupTChanIO
-	, readTChanIO
-	, tryReadTChanIO
-	, peekTChanIO
-	, tryPeekTChanIO
-	, writeTChanIO
+    , readTChanIO
+    , tryReadTChanIO
+    , peekTChanIO
+    , tryPeekTChanIO
+    , writeTChanIO
     , unGetTChanIO
     , isEmptyTChanIO
     , cloneTChanIO
     ) where
-
 
 import Control.Concurrent.STM.TChan as All
     hiding (newTChanIO, newBroadcastTChanIO)

--- a/src/Control/Concurrent/STM/TMVar/Lifted.hs
+++ b/src/Control/Concurrent/STM/TMVar/Lifted.hs
@@ -1,15 +1,15 @@
 module Control.Concurrent.STM.TMVar.Lifted
-	( module All
+    ( module All
     , newTMVarIO
-	, newEmptyTMVarIO
-	, takeTMVarIO
-	, putTMVarIO
-	, readTMVarIO
-	, tryReadTMVarIO
-	, swapTMVarIO
-	, tryTakeTMVarIO
-	, tryPutTMVarIO
-	, isEmptyTMVarIO
+    , newEmptyTMVarIO
+    , takeTMVarIO
+    , putTMVarIO
+    , readTMVarIO
+    , tryReadTMVarIO
+    , swapTMVarIO
+    , tryTakeTMVarIO
+    , tryPutTMVarIO
+    , isEmptyTMVarIO
     ) where
 
 import Control.Concurrent.STM.TMVar as All

--- a/src/Control/Concurrent/STM/TQueue/Lifted.hs
+++ b/src/Control/Concurrent/STM/TQueue/Lifted.hs
@@ -1,11 +1,11 @@
 module Control.Concurrent.STM.TQueue.Lifted
     ( module All
-	, newTQueueIO
-	, readTQueueIO
-	, tryReadTQueueIO
-	, peekTQueueIO
-	, tryPeekTQueueIO
-	, writeTQueueIO
+    , newTQueueIO
+    , readTQueueIO
+    , tryReadTQueueIO
+    , peekTQueueIO
+    , tryPeekTQueueIO
+    , writeTQueueIO
     , unGetTQueueIO
     , isEmptyTQueueIO
     ) where

--- a/src/Control/Concurrent/STM/TVar/Lifted.hs
+++ b/src/Control/Concurrent/STM/TVar/Lifted.hs
@@ -34,4 +34,3 @@ modifyTVarIO' = atomically .: modifyTVar'
 
 swapTVarIO :: MonadIO m => TVar a -> a -> m a
 swapTVarIO = atomically .: swapTVar
-

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,1 @@
+resolver: lts-8.16

--- a/stm-lifted.cabal
+++ b/stm-lifted.cabal
@@ -1,5 +1,5 @@
 name:		stm-lifted
-version:        0.1.0.0
+version:        0.1.1.0
 synopsis:	Software Transactional Memory lifted to MonadIO
 license:	BSD3
 license-file:	LICENSE
@@ -14,7 +14,7 @@ cabal-version:  >= 1.10
 
 description:
  A MonadIO version of
- <http://hackage.haskell.org/package/stm-2.4.2 STM> library.
+ <http://hackage.haskell.org/package/stm-2.4.4.1 STM> library.
 
 
 source-repository head
@@ -34,6 +34,6 @@ library
     , Control.Concurrent.STM.TSem.Lifted
   other-modules: Internal
   build-depends:
-      base          >= 4.5   && < 5
-    , transformers  >= 0.2   && < 0.6
-    , stm           >= 2.4.2 && < 3
+      base          >= 4.5     && < 5
+    , transformers  >= 0.2     && < 0.6
+    , stm           >= 2.4.4.1 && < 3

--- a/stm-lifted.cabal
+++ b/stm-lifted.cabal
@@ -35,6 +35,5 @@ library
   other-modules: Internal
   build-depends:
       base          >= 4.5   && < 5
-    , transformers  >= 0.2   && < 0.5
+    , transformers  >= 0.2   && < 0.6
     , stm           >= 2.4.2 && < 3
-


### PR DESCRIPTION
Hey,
This patchset introduces one new combinator (`isFullTBQueue`), dep upper limits bumped. I chose not to maintain compatibility with older `stm` versions because they seem old enough to not care about (`stm-2.4` was released 2.5 years ago).